### PR TITLE
Make it work on PyPy 2.3.1/CentOS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: python
 python:
   - 2.6
   - 2.7
+  - pypy
 script:  python setup.py test

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Michael Axiak
 Rob Stacey
 dlecocq - For superfast addition
 pbutler - Fix memory leak
+Dan Crosta - Convert MurmurHash3 to C from C++

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ ext_files = ["src/mmapbitarray.c",
              "src/bloomfilter.c",
              "src/md5.c",
              "src/primetester.c",
-             "src/MurmurHash3.cpp",
+             "src/MurmurHash3.c",
              ]
 
 kwargs = {}

--- a/src/MurmurHash3.c
+++ b/src/MurmurHash3.c
@@ -10,9 +10,7 @@
 // modification in mmh3:
 // __attribute__((always_inline)) is replaced to inline by Hajime Senuma
 
-extern "C" {
 #include "MurmurHash3.h"
-}
 
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros
@@ -57,12 +55,12 @@ inline uint64_t rotl64 ( uint64_t x, int8_t r )
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
 
-FORCE_INLINE uint32_t getblock ( const uint32_t * p, int i )
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
 {
   return p[i];
 }
 
-FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
 {
   return p[i];
 }
@@ -70,7 +68,7 @@ FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
 //-----------------------------------------------------------------------------
 // Finalization mix - force all bits of a hash block to avalanche
 
-FORCE_INLINE uint32_t fmix ( uint32_t h )
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
 {
   h ^= h >> 16;
   h *= 0x85ebca6b;
@@ -83,7 +81,7 @@ FORCE_INLINE uint32_t fmix ( uint32_t h )
 
 //----------
 
-FORCE_INLINE uint64_t fmix ( uint64_t k )
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 {
   k ^= k >> 33;
   k *= BIG_CONSTANT(0xff51afd7ed558ccd);
@@ -94,7 +92,6 @@ FORCE_INLINE uint64_t fmix ( uint64_t k )
   return k;
 }
 
-extern "C" {
 
 //-----------------------------------------------------------------------------
 
@@ -114,9 +111,10 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
 
-  for(int i = -nblocks; i; i++)
+  int i;
+  for(i = -nblocks; i; i++)
   {
-    uint32_t k1 = getblock(blocks,i);
+    uint32_t k1 = getblock32(blocks,i);
 
     k1 *= c1;
     k1 = ROTL32(k1,15);
@@ -147,7 +145,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   h1 ^= len;
 
-  h1 = fmix(h1);
+  h1 = fmix32(h1);
 
   *(uint32_t*)out = h1;
 } 
@@ -175,12 +173,13 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
   const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
 
-  for(int i = -nblocks; i; i++)
+  int i;
+  for(i = -nblocks; i; i++)
   {
-    uint32_t k1 = getblock(blocks,i*4+0);
-    uint32_t k2 = getblock(blocks,i*4+1);
-    uint32_t k3 = getblock(blocks,i*4+2);
-    uint32_t k4 = getblock(blocks,i*4+3);
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
 
     k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
 
@@ -243,10 +242,10 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
   h1 += h2; h1 += h3; h1 += h4;
   h2 += h1; h3 += h1; h4 += h1;
 
-  h1 = fmix(h1);
-  h2 = fmix(h2);
-  h3 = fmix(h3);
-  h4 = fmix(h4);
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
 
   h1 += h2; h1 += h3; h1 += h4;
   h2 += h1; h3 += h1; h4 += h1;
@@ -275,10 +274,11 @@ void MurmurHash3_x64_128 ( const void * key, const int len, const uint32_t seed,
 
   const uint64_t * blocks = (const uint64_t *)(data);
 
-  for(int i = 0; i < nblocks; i++)
+  int i;
+  for(i = 0; i < nblocks; i++)
   {
-    uint64_t k1 = getblock(blocks,i*2+0);
-    uint64_t k2 = getblock(blocks,i*2+1);
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
 
     k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
 
@@ -299,23 +299,23 @@ void MurmurHash3_x64_128 ( const void * key, const int len, const uint32_t seed,
 
   switch(len & 15)
   {
-  case 15: k2 ^= uint64_t(tail[14]) << 48;
-  case 14: k2 ^= uint64_t(tail[13]) << 40;
-  case 13: k2 ^= uint64_t(tail[12]) << 32;
-  case 12: k2 ^= uint64_t(tail[11]) << 24;
-  case 11: k2 ^= uint64_t(tail[10]) << 16;
-  case 10: k2 ^= uint64_t(tail[ 9]) << 8;
-  case  9: k2 ^= uint64_t(tail[ 8]) << 0;
+  case 15: k2 ^= (uint64_t)(tail[14]) << 48;
+  case 14: k2 ^= (uint64_t)(tail[13]) << 40;
+  case 13: k2 ^= (uint64_t)(tail[12]) << 32;
+  case 12: k2 ^= (uint64_t)(tail[11]) << 24;
+  case 11: k2 ^= (uint64_t)(tail[10]) << 16;
+  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8;
+  case  9: k2 ^= (uint64_t)(tail[ 8]) << 0;
            k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
 
-  case  8: k1 ^= uint64_t(tail[ 7]) << 56;
-  case  7: k1 ^= uint64_t(tail[ 6]) << 48;
-  case  6: k1 ^= uint64_t(tail[ 5]) << 40;
-  case  5: k1 ^= uint64_t(tail[ 4]) << 32;
-  case  4: k1 ^= uint64_t(tail[ 3]) << 24;
-  case  3: k1 ^= uint64_t(tail[ 2]) << 16;
-  case  2: k1 ^= uint64_t(tail[ 1]) << 8;
-  case  1: k1 ^= uint64_t(tail[ 0]) << 0;
+  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56;
+  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48;
+  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40;
+  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32;
+  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24;
+  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16;
+  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8;
+  case  1: k1 ^= (uint64_t)(tail[ 0]) << 0;
            k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
   };
 
@@ -327,8 +327,8 @@ void MurmurHash3_x64_128 ( const void * key, const int len, const uint32_t seed,
   h1 += h2;
   h2 += h1;
 
-  h1 = fmix(h1);
-  h2 = fmix(h2);
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
 
   h1 += h2;
   h2 += h1;
@@ -337,5 +337,4 @@ void MurmurHash3_x64_128 ( const void * key, const int len, const uint32_t seed,
   ((uint64_t*)out)[1] = h2;
 }
 
-} // extern "C"
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
I was getting this error when trying to import pybloomfiltermmap in PyPy 2.3.1 on CentOS 6.

```
ImportError: unable to load extension module '/usr/lib64/pypy-2.3.1/site-packages/pybloomfilter.pypy-23.so': /usr/lib64/pypy-2.3.1/site-packages/pybloomfilter.pypy-23.so: undefined symbol: __gxx_personality_v0
```

I didn't especially bother to figure out what was going on, or whether it was caused by PyPy or CentOS (though anecdotally it's probably CentOS or the versions of build chain there -- PyPy 2.3.1 on my mac works fine).

In any event, converting the C++ to C was straightforward and, I believe, safe. All tests are passing, and there are no errors nor warnings.