### PR TITLE
Update Makefile to use environment FLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
+CC ?= gcc
+
 bloomfilter: mmapbitarray.* bloomfilter.*
-	gcc -lm -O3 mmapbitarray.c md5.c MurmurHash3.cpp bloomfilter.c -o bf
+	$(CC) $(CFLAGS) $(CPPFLAGS) -O3 mmapbitarray.c md5.c MurmurHash3.cpp bloomfilter.c -o bf -lm $(LDFLAGS)
 
 mbarray: mmapbitarray.*
-	gcc -lm -O3 -DMBAQUERY mmapbitarray.c -o mbaquery
-	gcc -lm -O3 -DMBACREATE mmapbitarray.c -o mbacreate
+	$(CC) $(CFLAGS) $(CPPFLAGS) -O3 -DMBAQUERY mmapbitarray.c -o mbaquery -lm $(LDFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -O3 -DMBACREATE mmapbitarray.c -o mbacreate -lm $(LDFLAGS)


### PR DESCRIPTION
move also -lm to the bottom, to avoid strip and build error when -Wl,--as-needed flag is set by default (e.g. on Ubuntu)
Closes: #63