### PR TITLE
Filter broken for large bit arrays

### DIFF
--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -68,7 +68,7 @@ BloomFilter *bloomfilter_Create_Mmap(size_t max_num_elem, double error_rate,
 
     /* After we create the new array object, this array may already
        have all of the bloom filter data from the file in the
-       header info. 
+       header info.
        By calling mbarray_Header, we copy that header data
        back into this BloomFilter object.
     */
@@ -145,7 +145,7 @@ BloomFilter * bloomfilter_Copy_Template(BloomFilter * src, char * filename, int 
 }
 
 
-uint32_t _hash_long(uint32_t hash_seed, Key * key) {
+BTYPE _hash_long(uint32_t hash_seed, Key * key) {
     Key newKey = {
         .shash = (char *)&key->nhash,
         .nhash = sizeof(key->nhash)
@@ -175,11 +175,11 @@ uint32_t _hash_char(uint32_t hash_seed, Key * key) {
 
 /* Code for MurmurHash3 */
 #include "MurmurHash3.h"
-uint32_t _hash_char(uint32_t hash_seed, Key * key) {
-    uint32_t hashed_pieces[4];
+BTYPE _hash_char(uint32_t hash_seed, Key * key) {
+    BTYPE hashed_pieces[2];
     MurmurHash3_x64_128((const void *)key->shash, (int)key->nhash,
                        hash_seed, &hashed_pieces);
-    return hashed_pieces[0] ^ hashed_pieces[1] ^ hashed_pieces[2] ^ hashed_pieces[3];
+    return hashed_pieces[0] ^ hashed_pieces[1];
 }
 
 

--- a/src/bloomfilter.h
+++ b/src/bloomfilter.h
@@ -2,6 +2,7 @@
 #define __BLOOMFILTER_H 1
 
 #include <stdlib.h>
+
 #include "mmapbitarray.h"
 #define BF_CURRENT_VERSION 1
 
@@ -41,18 +42,18 @@ int bloomfilter_Update(BloomFilter * bf, char * data, int size);
 BloomFilter * bloomfilter_Copy_Template(BloomFilter * src, char * filename, int perms);
 
 /* A lot of this is inlined.. */
-uint32_t _hash_char(uint32_t hash_seed, Key * key);
+BTYPE _hash_char(uint32_t hash_seed, Key * key);
 
-uint32_t _hash_long(uint32_t hash_seed, Key * key);
+BTYPE _hash_long(uint32_t hash_seed, Key * key);
 
 
 static inline int bloomfilter_Add(BloomFilter * bf, Key * key)
 {
-    uint32_t (*hashfunc)(uint32_t, Key *) = _hash_char;
+    BTYPE (*hashfunc)(uint32_t, Key *) = _hash_char;
     register BTYPE mod = bf->array->bits;
     register int i;
     register int result = 1;
-    register uint32_t hash_res;
+    register BTYPE hash_res;
 
     if (key->shash == NULL)
         hashfunc = _hash_long;
@@ -77,7 +78,7 @@ __attribute__((always_inline))
 static inline int bloomfilter_Test(BloomFilter * bf, Key * key)
 {
     register BTYPE mod = bf->array->bits;
-    register uint32_t (*hashfunc)(uint32_t, Key *) = _hash_char;
+    register BTYPE (*hashfunc)(uint32_t, Key *) = _hash_char;
     register int i;
 
     if (key->shash == NULL)

--- a/src/mmapbitarray.h
+++ b/src/mmapbitarray.h
@@ -69,7 +69,7 @@ char * mbarray_CharData(MBArray * array);
 
 static inline size_t _vector_offset(MBArray * array, BTYPE bit)
 {
-    return array->preamblesize + bit / (sizeof(DTYPE) << 3);
+    return (size_t)(array->preamblesize + bit / (sizeof(DTYPE) << 3));
 }
 __attribute__((always_inline))
 


### PR DESCRIPTION
The filter stops working once the number of bits overflows uint32_t, even though the bit array supports 64 bits no problem (there are warnings about this implicit downcasting during compilation too).

The result is a broken Bloom filter, whose capacity is effectively limited to the first 4bn bits (32bit). The error rate/capacity specified by the user is effectively truncated, leading to silent, massive error rates when processing large datasets (that's how we discovered this bug).

This PR changes the hash to produce bit array's `BTYPE` (64bit), so that it works correctly even with larger filters (more than 4bn bits).